### PR TITLE
Allow always uploading data to PVOutput

### DIFF
--- a/config-org.cfg
+++ b/config-org.cfg
@@ -45,13 +45,19 @@ port = 8899
 # time to wait for inverter logger response
 timeout = 3
 
+
 ### repeat this for every inverter ID that must be logged to pvoutput
 ### The apikey(s) and sysid(s) can be found at http://pvoutput.org/account.jsp
 [pvout]
-#use apikey-<inverter serial> in the apikey name
+# use apikey-<inverter serial> in the apikey name
 apikey-NLBN1234567A1234 = NOTAREALAPIKEY86e2258d4e29169fb79cf18b00
-#use sysid-<inverter serial> in the sysid name
+# use sysid-<inverter serial> in the sysid name
 sysid-NLBN1234567A1234  = 12345
+# By default the data is only uploaded every 5th minute of the hour. If you are polling less
+# frequently then once per minute, or when your inverter pushes data at a lower frequency, you may
+# need to push the data always, or data will never be uploaded. Otherwise you should not enable
+# this feature, to prevent sending too many requests to pvoutput.
+# always-upload-NLBN1234567A1234 = true
 
 ### use domoticz-<INVERTER SERIAL> as section name
 ### repeat this section for every inverter ID that must be logged to domoticz

--- a/outputs/PVoutputOutput.py
+++ b/outputs/PVoutputOutput.py
@@ -21,7 +21,10 @@ class PVoutputOutput(PluginLoader.Plugin):
         timezoner = timezone('Europe/Amsterdam')
         now = datetime.now(timezoner)
 
-        if (now.minute % 5) == 0:  # Only run at every 5 minute interval
+        always_upload_option = 'always-upload-'+msg.id
+        always_upload = self.config.getboolean('pvout', always_upload_option, fallback=False)
+
+        if always_upload or (now.minute % 5) == 0:
 
             sys_id = 'sysid-'+msg.id
             if not self.config.has_option('pvout', sys_id):


### PR DESCRIPTION
Fixes #34: You can now configure whether data should always be uploaded to PVOutput, or only every fifth minute.